### PR TITLE
Update Laravel support to ^11.0|^12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "illuminate/support": "^12.0",
+        "illuminate/support": "^11.0|^12.0",
         "php": "^8.2|^8.3|^8.4"
     },
     "require-dev": {


### PR DESCRIPTION
This updates the illuminate/support package requirement from Laravel 9-10 to Laravel 11-12, providing compatibility with the latest Laravel versions.